### PR TITLE
fix: 권한 비교 로직 수정

### DIFF
--- a/app/interceptors/auth_interceptor.rb
+++ b/app/interceptors/auth_interceptor.rb
@@ -16,7 +16,7 @@ class AuthInterceptor < GRPC::ServerInterceptor
     end
 
     user_code = call.metadata['x-user-code']
-    user_role = (call.metadata['x-user-role'] || "student").to_s.upcase  # << 핵심 수정
+    user_role = (call.metadata['x-user-role'] || "student").to_s.downcase
 
     if user_code.nil? || user_code.empty?
       raise UNAUTHENTICATED


### PR DESCRIPTION
- 각 서비스에서 비교하고 있는 권한 이름이 소문자임으로 인터셉터에서 "대문자 변환"을 "소문자 변환"으로 수정